### PR TITLE
Auto discovery bsky

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,24 +1,24 @@
-import { defineConfig } from 'astro/config';
-import mdx from '@astrojs/mdx';
-import sitemap from '@astrojs/sitemap';
+import { defineConfig } from "astro/config";
+import mdx from "@astrojs/mdx";
+import sitemap from "@astrojs/sitemap";
 import icon from "astro-icon";
-import { remarkReadingTime } from './remark-reading-time.mjs';
-import netlify from '@astrojs/netlify';
-import rehypeExternalLinks from 'rehype-external-links';
-import { shikiThemes, shikiDefaultColor } from './shiki.config.mjs';
+import { remarkReadingTime } from "./remark-reading-time.mjs";
+import netlify from "@astrojs/netlify";
+import rehypeExternalLinks from "rehype-external-links";
+import { shikiThemes, shikiDefaultColor } from "./shiki.config.mjs";
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://www.jonathanyeong.com',
+  site: "https://jonathanyeong.com",
   integrations: [mdx(), sitemap(), icon()],
   markdown: {
     drafts: false,
     shikiConfig: {
       themes: shikiThemes,
-      defaultColor: shikiDefaultColor
+      defaultColor: shikiDefaultColor,
     },
     remarkPlugins: [remarkReadingTime],
-    rehypePlugins: [[rehypeExternalLinks, { target: '_blank' }]]
+    rehypePlugins: [[rehypeExternalLinks, { target: "_blank" }]],
   },
-  adapter: netlify()
+  adapter: netlify(),
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@astrojs/netlify": "^6.6.3",
 				"@astrojs/rss": "^4.0.14",
 				"@astrojs/sitemap": "^3.6.0",
+				"@atproto/api": "^0.18.16",
 				"@tryghost/admin-api": "^1.14.2",
 				"@tryghost/content-api": "^1.12.2",
 				"@types/tryghost__admin-api": "^0.0.1",
@@ -23,7 +24,8 @@
 				"markdown-it": "^14.1.0",
 				"mdast-util-to-string": "^4.0.0",
 				"reading-time": "^1.5.0",
-				"rehype-external-links": "^3.0.0"
+				"rehype-external-links": "^3.0.0",
+				"ufo": "^1.6.3"
 			},
 			"devDependencies": {
 				"@astrojs/check": "^0.9.6",
@@ -270,6 +272,85 @@
 			"license": "MIT",
 			"dependencies": {
 				"yaml": "^2.5.0"
+			}
+		},
+		"node_modules/@atproto/api": {
+			"version": "0.18.16",
+			"resolved": "https://registry.npmjs.org/@atproto/api/-/api-0.18.16.tgz",
+			"integrity": "sha512-tRGKSWr83pP5CQpSboePU21pE+GqLDYy1XHae4HH4hjaT0pr5V8wNgu70kbKB0B02GVUumeDRpJnlHKD+eMzLg==",
+			"license": "MIT",
+			"dependencies": {
+				"@atproto/common-web": "^0.4.12",
+				"@atproto/lexicon": "^0.6.0",
+				"@atproto/syntax": "^0.4.2",
+				"@atproto/xrpc": "^0.7.7",
+				"await-lock": "^2.2.2",
+				"multiformats": "^9.9.0",
+				"tlds": "^1.234.0",
+				"zod": "^3.23.8"
+			}
+		},
+		"node_modules/@atproto/common-web": {
+			"version": "0.4.12",
+			"resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.4.12.tgz",
+			"integrity": "sha512-3aCJemqM/fkHQrVPbTCHCdiVstKFI+2LkFLvUhO6XZP0EqUZa/rg/CIZBKTFUWu9I5iYiaEiXL9VwcDRpEevSw==",
+			"license": "MIT",
+			"dependencies": {
+				"@atproto/lex-data": "0.0.8",
+				"@atproto/lex-json": "0.0.8",
+				"zod": "^3.23.8"
+			}
+		},
+		"node_modules/@atproto/lex-data": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.0.8.tgz",
+			"integrity": "sha512-1Y5tz7BkS7380QuLNXaE8GW8Xba+mRWugt8BKM4BUFYjjUZdmirU8lr72iM4XlEBrzRu8Cfvj+MbsbYaZv+IgA==",
+			"license": "MIT",
+			"dependencies": {
+				"@atproto/syntax": "0.4.2",
+				"multiformats": "^9.9.0",
+				"tslib": "^2.8.1",
+				"uint8arrays": "3.0.0",
+				"unicode-segmenter": "^0.14.0"
+			}
+		},
+		"node_modules/@atproto/lex-json": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.0.8.tgz",
+			"integrity": "sha512-w1Qmkae1QhmNz+i1Zm3xr3jp0UPPRENmdlpU0qIrdxWDo9W4Mzkeyc3eSoa+Zs+zN8xkRSQw7RLZte/B7Ipdwg==",
+			"license": "MIT",
+			"dependencies": {
+				"@atproto/lex-data": "0.0.8",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@atproto/lexicon": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.6.0.tgz",
+			"integrity": "sha512-5veb8aD+J5M0qszLJ+73KSFsFrJBgAY/nM1TSAJvGY7fNc9ZAT+PSUlmIyrdye9YznAZ07yktalls/TwNV7cHQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@atproto/common-web": "^0.4.7",
+				"@atproto/syntax": "^0.4.2",
+				"iso-datestring-validator": "^2.2.2",
+				"multiformats": "^9.9.0",
+				"zod": "^3.23.8"
+			}
+		},
+		"node_modules/@atproto/syntax": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.4.2.tgz",
+			"integrity": "sha512-X9XSRPinBy/0VQ677j8VXlBsYSsUXaiqxWVpGGxJYsAhugdQRb0jqaVKJFtm6RskeNkV6y9xclSUi9UYG/COrA==",
+			"license": "MIT"
+		},
+		"node_modules/@atproto/xrpc": {
+			"version": "0.7.7",
+			"resolved": "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.7.7.tgz",
+			"integrity": "sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==",
+			"license": "MIT",
+			"dependencies": {
+				"@atproto/lexicon": "^0.6.0",
+				"zod": "^3.23.8"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -4199,6 +4280,12 @@
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"license": "MIT"
 		},
+		"node_modules/await-lock": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+			"integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+			"license": "MIT"
+		},
 		"node_modules/axios": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
@@ -7573,6 +7660,12 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"license": "ISC"
 		},
+		"node_modules/iso-datestring-validator": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/iso-datestring-validator/-/iso-datestring-validator-2.2.2.tgz",
+			"integrity": "sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==",
+			"license": "MIT"
+		},
 		"node_modules/jackspeak": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -9290,6 +9383,12 @@
 			"integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/multiformats": {
+			"version": "9.9.0",
+			"resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+			"integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+			"license": "(Apache-2.0 AND MIT)"
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
@@ -11509,6 +11608,15 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
+		"node_modules/tlds": {
+			"version": "1.261.0",
+			"resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
+			"integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
+			"license": "MIT",
+			"bin": {
+				"tlds": "bin.js"
+			}
+		},
 		"node_modules/tmp": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -11674,10 +11782,19 @@
 			"license": "MIT"
 		},
 		"node_modules/ufo": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-			"integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+			"integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
 			"license": "MIT"
+		},
+		"node_modules/uint8arrays": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
+			"integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+			"license": "MIT",
+			"dependencies": {
+				"multiformats": "^9.4.2"
+			}
 		},
 		"node_modules/ulid": {
 			"version": "3.0.2",
@@ -11724,6 +11841,12 @@
 				"base64-js": "^1.3.0",
 				"unicode-trie": "^2.0.0"
 			}
+		},
+		"node_modules/unicode-segmenter": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/unicode-segmenter/-/unicode-segmenter-0.14.5.tgz",
+			"integrity": "sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==",
+			"license": "MIT"
 		},
 		"node_modules/unicode-trie": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"@astrojs/netlify": "^6.6.3",
 		"@astrojs/rss": "^4.0.14",
 		"@astrojs/sitemap": "^3.6.0",
+		"@atproto/api": "^0.18.16",
 		"@tryghost/admin-api": "^1.14.2",
 		"@tryghost/content-api": "^1.12.2",
 		"@types/tryghost__admin-api": "^0.0.1",
@@ -25,7 +26,8 @@
 		"markdown-it": "^14.1.0",
 		"mdast-util-to-string": "^4.0.0",
 		"reading-time": "^1.5.0",
-		"rehype-external-links": "^3.0.0"
+		"rehype-external-links": "^3.0.0",
+		"ufo": "^1.6.3"
 	},
 	"devDependencies": {
 		"@astrojs/check": "^0.9.6",

--- a/src/lib/loaders/ghostPosts.ts
+++ b/src/lib/loaders/ghostPosts.ts
@@ -110,6 +110,9 @@ export function ghostPostLoader(): Loader {
             });
           }
         }
+        logger.info(
+          `Loaded bskyPostMap with ${bskyPostMap.size} number of entries`,
+        );
 
         for (const post of allPosts) {
           const id = post.slug;

--- a/src/lib/loaders/ghostPosts.ts
+++ b/src/lib/loaders/ghostPosts.ts
@@ -59,13 +59,6 @@ export function ghostPostLoader(): Loader {
 
         let cutoffDate = new Date();
         for (const post of allPosts) {
-          if (extractBskyPostId(post.codeinjection_foot || "")) {
-            // We can early exit here for these reasons:
-            // - Posts are ordered by publishedAt DESC
-            // - I've added codeinjection_foot to my posts before implementing bsky auto-discovery
-            // As soon extractBskyPostId returns a value then I know I've hit the posts where I've already added a bsky postId
-            break;
-          }
           const publishedAt = post.published_at
             ? new Date(post.published_at)
             : undefined;

--- a/src/lib/loaders/ghostPosts.ts
+++ b/src/lib/loaders/ghostPosts.ts
@@ -59,6 +59,9 @@ export function ghostPostLoader(): Loader {
 
         let cutoffDate = new Date();
         for (const post of allPosts) {
+          if (extractBskyPostId(post.codeinjection_foot || "")) {
+            continue;
+          }
           const publishedAt = post.published_at
             ? new Date(post.published_at)
             : undefined;
@@ -104,6 +107,9 @@ export function ghostPostLoader(): Loader {
               logger.warn(`URI for bskypost is undefined: ${bskyPost.uri}`);
               continue;
             }
+            logger.info(
+              `Setting bskyPostMap ${bskyPost.links[0]} with bskyPostId ${bskyPostId}`,
+            );
             bskyPostMap.set(bskyPost.links[0], {
               createdAt: bskyPost.createdAt,
               bskyPostId,
@@ -119,8 +125,8 @@ export function ghostPostLoader(): Loader {
           let bskyPostId = extractBskyPostId(post.codeinjection_foot || "");
           if (!bskyPostId) {
             const bskyPost = bskyPostMap.get(post.slug);
-            logger.info(`post.slug: ${post.slug} bskyPost: ${bskyPost}`);
             if (bskyPost) {
+              logger.info(`Auto-discovered bskyPostId for ${post.slug}`);
               bskyPostId = bskyPost.bskyPostId;
             }
           }

--- a/src/lib/loaders/ghostPosts.ts
+++ b/src/lib/loaders/ghostPosts.ts
@@ -1,19 +1,30 @@
-import type { Loader, LoaderContext } from 'astro/loaders';
-import { ghostClient } from '@lib/api/ghost';
-import { unified } from 'unified';
-import rehypeParse from 'rehype-parse';
-import rehypeShiki from '@shikijs/rehype'
-import rehypeStringify from 'rehype-stringify';
-import { shikiThemes, shikiDefaultColor } from '../../../shiki.config.mjs';
+import type { Loader, LoaderContext } from "astro/loaders";
+import { ghostClient } from "@lib/api/ghost";
+import { unified } from "unified";
+import rehypeParse from "rehype-parse";
+import rehypeShiki from "@shikijs/rehype";
+import rehypeStringify from "rehype-stringify";
+import { shikiThemes, shikiDefaultColor } from "../../../shiki.config.mjs";
+import { AtpAgent, AppBskyFeedPost } from "@atproto/api";
+import { site } from "astro:config/client";
+import { parseURL, withoutTrailingSlash } from "ufo";
+
+interface ParsedPost {
+  uri: string;
+  createdAt: string;
+  links: string[]; // URLs found in facets and embeds
+}
 
 function extractBskyPostId(codeInjection: string): string | undefined {
-  const match = codeInjection.match(/<!--\s*METADATA:\s*bskyPostId=([a-zA-Z0-9]+)\s*-->/);
+  const match = codeInjection.match(
+    /<!--\s*METADATA:\s*bskyPostId=([a-zA-Z0-9]+)\s*-->/,
+  );
   return match?.[1];
 }
 
 export function ghostPostLoader(): Loader {
   return {
-    name: 'ghostcms-posts',
+    name: "ghostcms-posts",
 
     load: async ({ store, logger, parseData }: LoaderContext) => {
       try {
@@ -21,14 +32,15 @@ export function ghostPostLoader(): Loader {
         let hasMore = true;
         const allPosts = [];
 
-        logger.info('Starting to fetch Ghost posts...');
+        logger.info("Starting to fetch Ghost posts...");
 
         while (hasMore) {
           const posts = await ghostClient.posts.browse({
             limit: 100,
             page: page,
-            include: ['tags'],
-            filter: 'tag:-hash-newsletter'
+            include: ["tags"],
+            filter: "tag:-hash-newsletter",
+            order: "published_at DESC",
           });
 
           allPosts.push(...posts);
@@ -39,24 +51,97 @@ export function ghostPostLoader(): Loader {
             page = nextPage;
           }
 
-          logger.info(`Fetched page ${posts.meta.pagination.page} of ${posts.meta.pagination.pages}`);
+          logger.info(
+            `Fetched page ${posts.meta.pagination.page} of ${posts.meta.pagination.pages}`,
+          );
         }
-
         logger.info(`Loaded ${allPosts.length} posts from Ghost`);
 
+        let cutoffDate = new Date();
         for (const post of allPosts) {
-          const id = post.slug
-          const bskyPostId = extractBskyPostId(post.codeinjection_foot || '');
+          if (extractBskyPostId(post.codeinjection_foot || "")) {
+            // We can early exit here for these reasons:
+            // - Posts are ordered by publishedAt DESC
+            // - I've added codeinjection_foot to my posts before implementing bsky auto-discovery
+            // As soon extractBskyPostId returns a value then I know I've hit the posts where I've already added a bsky postId
+            break;
+          }
+          const publishedAt = post.published_at
+            ? new Date(post.published_at)
+            : undefined;
+
+          if (publishedAt && cutoffDate > publishedAt) {
+            cutoffDate = publishedAt;
+          }
+        }
+
+        const agent = new AtpAgent({ service: "https://public.api.bsky.app" });
+        const feedIterator = createBlueskyFeedIterator(
+          agent,
+          "jonathanyeong.com",
+          cutoffDate,
+        );
+
+        logger.info(`Fetching Bluesky Posts with cutoffDate: ${cutoffDate}`);
+        while (!feedIterator.isExhausted()) {
+          await feedIterator.fetchMore();
+        }
+
+        let bskyPostMap = new Map<
+          string,
+          { createdAt: string; bskyPostId: string }
+        >();
+        for (const bskyPost of feedIterator.posts) {
+          // I'm assuming both the facet and embed will have the same link
+          // Hoping that doesn't bite me later
+          const { pathname } = parseURL(
+            withoutTrailingSlash(bskyPost.links[0]),
+          );
+
+          const slug = pathname.split("/").pop();
+
+          if (!slug) {
+            logger.warn(`slug for bskypost is undefined: ${bskyPost.links[0]}`);
+            continue;
+          }
+          const post = bskyPostMap.get(slug);
+          if (!post || post.createdAt > bskyPost.createdAt) {
+            const bskyPostId = bskyPost.uri.split("/").pop();
+            if (!bskyPostId) {
+              logger.warn(`URI for bskypost is undefined: ${bskyPost.uri}`);
+              continue;
+            }
+            bskyPostMap.set(bskyPost.links[0], {
+              createdAt: bskyPost.createdAt,
+              bskyPostId,
+            });
+          }
+        }
+
+        for (const post of allPosts) {
+          const id = post.slug;
+          let bskyPostId = extractBskyPostId(post.codeinjection_foot || "");
+          if (!bskyPostId) {
+            const bskyPost = bskyPostMap.get(post.slug);
+            logger.info(`post.slug: ${post.slug} bskyPost: ${bskyPost}`);
+            if (bskyPost) {
+              bskyPostId = bskyPost.bskyPostId;
+            }
+          }
           // Transformation done here to match the schema of our md blog collection.
           const rawData = {
             title: post.title,
-            description: post.custom_excerpt || post.excerpt || '',
-            pubDate: post.published_at ? new Date(post.published_at): undefined,
-            updatedDate: post.updated_at ? new Date(post.updated_at) : undefined,
+            description: post.custom_excerpt || post.excerpt || "",
+            pubDate: post.published_at
+              ? new Date(post.published_at)
+              : undefined,
+            updatedDate: post.updated_at
+              ? new Date(post.updated_at)
+              : undefined,
             heroImage: post.feature_image || undefined,
             draft: false, // Ghost posts are published by default
             featured: post.featured || false,
-            topics: post.tags?.map(tag => tag.name) || [],
+            topics: post.tags?.map((tag) => tag.name) || [],
             readingTime: post.reading_time,
             bskyPostId,
           };
@@ -70,14 +155,16 @@ export function ghostPostLoader(): Loader {
             id,
             data: parsedData,
             rendered: {
-              html: await highlightGhostCode(post.html || ''),
+              html: await highlightGhostCode(post.html || ""),
             },
           });
         }
 
-        logger.info('Ghost posts loaded successfully');
+        logger.info("Ghost posts loaded successfully");
       } catch (error) {
-        logger.error(`Ghost loader error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        logger.error(
+          `Ghost loader error: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
         throw error;
       }
     },
@@ -98,9 +185,9 @@ async function highlightGhostCode(html: string): Promise<string> {
       .use(rehypeParse, { fragment: true })
       .use(rehypeShiki, {
         themes: shikiThemes,
-        defaultLanguage: 'plaintext',
-        inline: 'tailing-curly-colon',
-        defaultColor: shikiDefaultColor
+        defaultLanguage: "plaintext",
+        inline: "tailing-curly-colon",
+        defaultColor: shikiDefaultColor,
       })
       .use(rehypeStringify)
       .process(html);
@@ -109,4 +196,107 @@ async function highlightGhostCode(html: string): Promise<string> {
   } catch (error) {
     return html;
   }
+}
+
+function createBlueskyFeedIterator(
+  agent: AtpAgent,
+  actor: string,
+  cutoffDate: Date,
+) {
+  const posts: ParsedPost[] = [];
+  let cursor: string | undefined;
+  let exhausted = false;
+  let oldestPostDate: Date | null = null;
+
+  async function fetchNextPage(): Promise<boolean> {
+    if (exhausted) return false;
+
+    try {
+      const { data } = await agent.getAuthorFeed({
+        actor,
+        limit: 100,
+        cursor,
+      });
+
+      for (const item of data.feed) {
+        // skip reposts
+        if (item.reason) continue;
+
+        const post = item.post;
+        if (!AppBskyFeedPost.isRecord(post.record)) continue;
+
+        const record = post.record;
+        const postDate = new Date(record.createdAt as string);
+
+        if (!oldestPostDate || postDate < oldestPostDate) {
+          oldestPostDate = postDate;
+        }
+
+        if (postDate < cutoffDate) {
+          exhausted = true;
+          break;
+        }
+
+        const links: string[] = [];
+
+        // Extract links from facets
+        const facets = record.facets as
+          | Array<{ features: Array<{ uri?: string; $type?: string }> }>
+          | undefined;
+        if (facets) {
+          for (const facet of facets) {
+            for (const feature of facet.features) {
+              if (
+                feature.$type === "app.bsky.richtext.facet#link" &&
+                feature.uri
+              ) {
+                links.push(feature.uri);
+              }
+            }
+          }
+        }
+
+        if (post.embed && "external" in post.embed) {
+          const external = post.embed.external as { uri?: string };
+          if (external.uri) {
+            links.push(external.uri);
+          }
+        }
+
+        if (
+          !links.some((link) =>
+            link.startsWith(site || "https://jonathanyeong.com"),
+          )
+        ) {
+          continue;
+        }
+        if (links.length > 0) {
+          posts.push({
+            uri: post.uri,
+            createdAt: record.createdAt as string,
+            links,
+          });
+        }
+      }
+
+      cursor = data.cursor;
+
+      if (!cursor) {
+        exhausted = true;
+      }
+
+      return true;
+    } catch {
+      exhausted = true;
+      return false;
+    }
+  }
+
+  return {
+    posts,
+    fetchMore: fetchNextPage,
+    getOldestPostDate: () => oldestPostDate,
+    /** Check if we've exhausted all pages */
+    isExhausted: () => exhausted,
+  };
 }


### PR DESCRIPTION
It leans on the work by Daniel Roe https://github.com/danielroe/roe.dev/blob/main/modules/bsky-comments.ts#L195.

This spaghetti code will load up all the bluesky posts from the cutoff date of the earliest blog post without a bsky post id. Once it gets all the bluesky post it transforms that array into a map that contains the slug => createdAt, bskyPostId. I might make the same post with the url multiple times so I need to store the earliest post. I can then access this map when parsing my Ghost Posts to fetch the bskyPostId. This also allows me to override the bskyPostId using my current method of some `codeinjection_foot` data.

I chose not to do anything in runtime because I don't know how expensive it is to pull from bsky. To try and keep my site fast I'm going to opt to using a cron in val.town which will run every 15 min.

